### PR TITLE
fix(factory): use generic and improve "create" type hint

### DIFF
--- a/gale/factory.py
+++ b/gale/factory.py
@@ -8,11 +8,13 @@ Author: Alejandro Mujica
 
 import sys
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, TypeVar, Generic
+
+T = TypeVar("T")
 
 
-class Factory:
-    def __init__(self, prototype: Type) -> None:
+class Factory(Generic[T]):
+    def __init__(self, prototype: T) -> None:
         """
         :param prototype: The data type that will be created by the factory.
         """
@@ -22,7 +24,7 @@ class Factory:
 
     def create(
         self, x: float, y: float, properties: Optional[Dict[str, any]] = None
-    ) -> None:
+    ) -> T:
         """
         Create a new object from the prototype.
 


### PR DESCRIPTION
Right now, `Factory#create` returns `None`, which messes up a little with linters.

Based on [Generics doc](https://docs.python.org/3/library/typing.html#generics):

- Make Factory extend Generic
- Use a TypeVar (T) on Factory's prototype
- Return the infered TypeVar (T) as return type, improving the type hint on different factories

e.g.:

<img width="557" alt="image" src="https://user-images.githubusercontent.com/34623660/219868385-bc652a3f-b2c2-4106-8c6f-7ffb12ddb205.png">

results in:

<img width="722" alt="image" src="https://user-images.githubusercontent.com/34623660/219868565-dfb72746-f025-439c-8e60-1c213393f650.png">
