### PR TITLE
Add Nightwatch: a stealth demo exercising gale.ai end to end

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,12 @@ built with gale, see ``examples/space_trip`` and, in particular for
 small stealth demo whose guards patrol, chase, and coordinate through a
 shared behavior tree, blackboard, and pathfinding.
 
+Each example under ``examples/`` is a standalone project (its own
+``settings.py`` and ``src/``), so it doesn't see the copy of ``gale``
+inside this repository unless it's actually installed. From the
+repository root, run ``pip install -e .`` once, then ``cd`` into the
+example's directory and run ``python main.py`` from there.
+
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,12 @@ Examples
 - `gale.timer <docs/examples/timer.rst>`_
 - `gale.ai <docs/examples/gale_ai.rst>`_: steering behaviors, behavior tree, decision tree, Blackboard, graphs/search, and the ``Agent`` class.
 
+These are short, focused snippets per module. For full running games
+built with gale, see ``examples/space_trip`` and, in particular for
+``gale.ai``, `examples/nightwatch <examples/nightwatch/README.md>`_, a
+small stealth demo whose guards patrol, chase, and coordinate through a
+shared behavior tree, blackboard, and pathfinding.
+
 
 Development
 -----------

--- a/examples/nightwatch/README.md
+++ b/examples/nightwatch/README.md
@@ -1,0 +1,44 @@
+# Nightwatch
+
+A small top-down stealth demo: sneak past two patrolling guards and a
+skittish civilian to reach the exit. It exists to exercise gale.ai (and
+the rest of gale) end to end, in an actual running game rather than in
+isolated snippets.
+
+Every visual is drawn with `pygame.draw` primitives (no image, font, or
+sound assets), so it runs as-is. The nav graph's edges are rendered as
+faint lines for the same reason the guards patrol it out loud: this is
+a showcase, not a polished game.
+
+## Running it
+
+```bash
+cd examples/nightwatch
+python main.py
+```
+
+## Controls
+
+- `WASD` / arrow keys: move
+- `Enter`: confirm (start, back to title)
+- `Ctrl+R`: restart the level at any time (a keyboard combo, see `gale.input_handler`)
+- `Escape`: quit
+
+## What it exercises
+
+- `gale.ai.steering`: `Kinematic`, `Seek`, `Pursue`, `Flee`, `Wander` drive the player's physical body and every NPC's movement.
+- `gale.ai.behavior_tree`: each `Guard`'s decision (chase / investigate / patrol) is a `Selector`/`Sequence`/`Condition`/`Action` tree, re-evaluated fresh every tick (see the docstring in `src/entities/Guard.py` for why every `Action` returns `SUCCESS`, never `RUNNING`).
+- `gale.ai.decision_tree`: the `Civilian` picks between fleeing and wandering with a single `DecisionNode`, as a simpler alternative to a behavior tree.
+- `gale.ai.blackboard`: all `Guard`s share one `Blackboard`. A guard that spots the player posts `alert_position`/`is_alerted` to it, so the *other* guard reacts and investigates without ever seeing the player itself. The HUD's "SPOTTED!" flash is a `Blackboard.observe` callback reacting to `is_alerted` immediately, instead of polling it every frame.
+- `gale.ai.graph` / `gale.ai.search`: `src/level.py` builds a `NavGraph` (a visibility graph over the level's wall corners) once, and guards path across it with `a_star` to investigate the last known player position, walking around walls instead of through them.
+- `gale.ai.agent.Agent`: `Player`, `Guard`, and `Civilian` are all `Agent` subclasses, spawned through `gale.factory.Factory`.
+- `gale.state`: a `StateMachine` drives `TitleState` → `PlayState` → `GameOverState`/`VictoryState`.
+- `gale.input_handler`: movement bindings (two keys per direction) plus the `Ctrl+R` modifier combo.
+- `gale.particle_system`: a burst plays wherever the player ends the level, colored red when caught and gold on the exit.
+- `gale.timer`: `Timer.tween` fades the level in on entry; `Timer.after` delays the state change until the particle burst has had a moment to play, and resets the one-shot alert flash.
+- `gale.text`: all HUD/menu text.
+
+`gale.ai.graph.DependencyGraph` is the one piece of `gale.ai` this demo
+doesn't use — a prerequisite/build-order graph doesn't have a natural
+place in real-time gameplay like this. See `docs/examples/gale_ai.rst`
+for a runnable example of it on its own.

--- a/examples/nightwatch/README.md
+++ b/examples/nightwatch/README.md
@@ -12,6 +12,16 @@ a showcase, not a polished game.
 
 ## Running it
 
+From the repository root, install gale itself in editable mode so it's
+importable from anywhere (only needed once):
+
+```bash
+pip install -e .
+```
+
+Then run the example from its own directory, since it looks for
+`settings.py` and `src/` next to `main.py`:
+
 ```bash
 cd examples/nightwatch
 python main.py

--- a/examples/nightwatch/main.py
+++ b/examples/nightwatch/main.py
@@ -1,0 +1,12 @@
+import settings
+from src.Nightwatch import Nightwatch
+
+if __name__ == "__main__":
+    game = Nightwatch(
+        "Nightwatch",
+        settings.WINDOW_WIDTH,
+        settings.WINDOW_HEIGHT,
+        settings.VIRTUAL_WIDTH,
+        settings.VIRTUAL_HEIGHT,
+    )
+    game.exec()

--- a/examples/nightwatch/settings.py
+++ b/examples/nightwatch/settings.py
@@ -33,15 +33,18 @@ VIRTUAL_HEIGHT = 360
 WINDOW_WIDTH = 1280
 WINDOW_HEIGHT = 720
 
-PLAYER_SPEED = 140
+PLAYER_SPEED = 160
 PLAYER_RADIUS = 8
 CATCH_RADIUS = 14
 
-GUARD_PATROL_SPEED = 90
-GUARD_CHASE_SPEED = 130
+# Guards patrol slower than they chase (Guard switches its Kinematic's
+# max_speed between the two), and chase noticeably slower than the
+# player moves, so a spotted player has a real chance to break away.
+GUARD_PATROL_SPEED = 70
+GUARD_CHASE_SPEED = 110
 GUARD_RADIUS = 10
-GUARD_SIGHT_RADIUS = 120
-GUARD_LOSE_INTEREST_TIME = 3.0
+GUARD_SIGHT_RADIUS = 85
+GUARD_LOSE_INTEREST_TIME = 2.2
 
 CIVILIAN_SPEED = 70
 CIVILIAN_FLEE_SPEED = 120

--- a/examples/nightwatch/settings.py
+++ b/examples/nightwatch/settings.py
@@ -1,0 +1,72 @@
+"""
+Nightwatch: a small top-down stealth demo built to exercise gale.ai
+(steering, behavior tree, decision tree, blackboard, graphs/search) on
+top of the rest of gale (game, state, input_handler, particle_system,
+timer, text, factory). Every visual is drawn with pygame.draw
+primitives, so it needs no image/font/sound assets to run.
+"""
+
+import pygame
+
+from gale import input_handler
+
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_ESCAPE, "quit")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_LEFT, "move_left")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_a, "move_left")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_RIGHT, "move_right")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_d, "move_right")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_UP, "move_up")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_w, "move_up")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_DOWN, "move_down")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_s, "move_down")
+input_handler.InputHandler.set_keyboard_action(input_handler.KEY_RETURN, "confirm")
+# A key combo (Ctrl+R) to restart, alongside the plain-key bindings above.
+input_handler.InputHandler.set_keyboard_action(
+    input_handler.KEY_r, "restart", modifiers=input_handler.MOD_CTRL
+)
+
+# Size we want to emulate
+VIRTUAL_WIDTH = 640
+VIRTUAL_HEIGHT = 360
+
+# Size of our actual window
+WINDOW_WIDTH = 1280
+WINDOW_HEIGHT = 720
+
+PLAYER_SPEED = 140
+PLAYER_RADIUS = 8
+CATCH_RADIUS = 14
+
+GUARD_PATROL_SPEED = 90
+GUARD_CHASE_SPEED = 130
+GUARD_RADIUS = 10
+GUARD_SIGHT_RADIUS = 120
+GUARD_LOSE_INTEREST_TIME = 3.0
+
+CIVILIAN_SPEED = 70
+CIVILIAN_FLEE_SPEED = 120
+CIVILIAN_RADIUS = 8
+CIVILIAN_FLEE_RADIUS = 90
+
+# How far obstacles are inflated (and nav graph corners pushed out) so
+# agents keep some clearance from walls instead of grazing corners.
+NAV_CLEARANCE = 16
+
+COLOR_BACKGROUND = (18, 20, 28)
+COLOR_WALL = (95, 98, 112)
+COLOR_EXIT = (230, 200, 60)
+COLOR_PLAYER = (90, 200, 255)
+COLOR_GUARD_PATROL = (210, 90, 90)
+COLOR_GUARD_ALERT = (255, 210, 60)
+COLOR_CIVILIAN = (120, 220, 130)
+COLOR_NAV_EDGE = (55, 60, 75)
+COLOR_TEXT = (235, 235, 235)
+COLOR_ALERT_TEXT = (255, 90, 90)
+
+# No custom font file needed for this demo, just pygame's built-in default.
+pygame.font.init()
+FONTS = {
+    "small": pygame.font.Font(None, 16),
+    "medium": pygame.font.Font(None, 24),
+    "large": pygame.font.Font(None, 40),
+}

--- a/examples/nightwatch/src/Nightwatch.py
+++ b/examples/nightwatch/src/Nightwatch.py
@@ -1,0 +1,32 @@
+import pygame
+
+from gale.game import Game
+from gale.input_handler import InputData
+from gale.state import StateMachine
+
+from src.states import GameOverState, PlayState, TitleState, VictoryState
+
+
+class Nightwatch(Game):
+    def init(self) -> None:
+        self.state_machine = StateMachine(
+            {
+                "title": TitleState,
+                "play": PlayState,
+                "game_over": GameOverState,
+                "victory": VictoryState,
+            }
+        )
+        self.state_machine.change("title")
+
+    def update(self, dt: float) -> None:
+        self.state_machine.update(dt)
+
+    def render(self, surface: pygame.Surface) -> None:
+        self.state_machine.render(surface)
+
+    def on_input(self, input_id: str, input_data: InputData) -> None:
+        if input_id == "quit" and input_data.pressed:
+            self.quit()
+        else:
+            self.state_machine.on_input(input_id, input_data)

--- a/examples/nightwatch/src/entities/Civilian.py
+++ b/examples/nightwatch/src/entities/Civilian.py
@@ -1,0 +1,79 @@
+from typing import List
+
+import pygame
+
+from gale.ai.agent import Agent
+from gale.ai.decision_tree import ActionNode, DecisionNode, DecisionTree
+from gale.ai.steering import Flee, Kinematic, Wander
+
+import settings
+from src import level
+
+
+class Civilian(Agent):
+    """
+    A neutral bystander driven by a DecisionTree (instead of a
+    BehaviorTree, like Guard) as a second, simpler way of picking a
+    steering behavior: flee from the nearest guard if one is close
+    enough, wander otherwise. A DecisionTree has no persistent RUNNING
+    state, so this test is naturally re-evaluated fresh every tick.
+    """
+
+    def __init__(self, x: float, y: float, guards: List[Agent]) -> None:
+        super().__init__(
+            x=x,
+            y=y,
+            max_speed=settings.CIVILIAN_FLEE_SPEED,
+            max_acceleration=settings.CIVILIAN_FLEE_SPEED * 6,
+        )
+        self.radius = settings.CIVILIAN_RADIUS
+        self.guards = guards
+
+        self.wander = Wander(
+            self.kinematic,
+            offset=40,
+            radius=25,
+            max_acceleration=settings.CIVILIAN_SPEED * 4,
+        )
+        self.flee = Flee(self.kinematic, Kinematic())
+
+        def near_a_guard(agent: Agent) -> bool:
+            return any(
+                (guard.position - self.position).length()
+                < settings.CIVILIAN_FLEE_RADIUS
+                for guard in self.guards
+            )
+
+        def flee_nearest_guard(agent: Agent) -> None:
+            nearest = min(
+                self.guards, key=lambda guard: (guard.position - self.position).length()
+            )
+            self.flee.target = nearest.kinematic
+            self.set_steering_behavior(self.flee)
+
+        def wander_around(agent: Agent) -> None:
+            self.set_steering_behavior(self.wander)
+
+        self.set_brain(
+            DecisionTree(
+                DecisionNode(
+                    test=near_a_guard,
+                    true_branch=ActionNode(flee_nearest_guard),
+                    false_branch=ActionNode(wander_around),
+                )
+            )
+        )
+
+    def update(self, dt: float) -> None:
+        super().update(dt)
+        self.kinematic.position = level.resolve_circle_vs_obstacles(
+            self.kinematic.position, self.radius
+        )
+
+    def render(self, surface: pygame.Surface) -> None:
+        pygame.draw.circle(
+            surface,
+            settings.COLOR_CIVILIAN,
+            (int(self.position.x), int(self.position.y)),
+            self.radius,
+        )

--- a/examples/nightwatch/src/entities/Guard.py
+++ b/examples/nightwatch/src/entities/Guard.py
@@ -1,0 +1,162 @@
+from typing import List, Optional, Tuple
+
+import pygame
+
+from gale.ai.agent import Agent
+from gale.ai.behavior_tree import (
+    Action,
+    BehaviorTree,
+    Condition,
+    Selector,
+    Sequence,
+    Status,
+)
+from gale.ai.blackboard import Blackboard
+from gale.ai.graph import NavGraph
+from gale.ai.steering import Pursue, Seek
+
+import settings
+from src import level
+from src.path_follower import PathFollower
+
+Point = Tuple[float, float]
+
+
+class Guard(Agent):
+    """
+    Patrols back and forth between two points. When it sees the player
+    (within sight radius and with a clear line of sight), it chases
+    them directly and posts the sighting on the shared squad
+    Blackboard, so every other Guard sharing it learns where to
+    investigate even without seeing the player themselves. If it loses
+    the player, it keeps investigating the last known position (path
+    found with A* over the level's NavGraph, since it has to walk
+    around walls) for a while before giving up and returning to patrol.
+
+    The whole decision is re-evaluated fresh every tick: every Action
+    below returns Status.SUCCESS (never RUNNING), which is what makes
+    the root Selector reset itself and re-check from the top (starting
+    with "do I currently see the player?") on every single tick,
+    instead of latching onto whichever branch ran last.
+    """
+
+    def __init__(
+        self,
+        x: float,
+        y: float,
+        patrol_points: Tuple[Point, Point],
+        player: Agent,
+        nav_graph: NavGraph,
+        blackboard: Blackboard,
+    ) -> None:
+        super().__init__(
+            x=x,
+            y=y,
+            max_speed=settings.GUARD_CHASE_SPEED,
+            max_acceleration=settings.GUARD_CHASE_SPEED * 6,
+            blackboard=blackboard,
+        )
+        self.radius = settings.GUARD_RADIUS
+        self.player = player
+        self.nav_graph = nav_graph
+
+        self._patrol_points: List[Point] = list(patrol_points)
+        self.patrol_follower = PathFollower()
+        self.patrol_follower.set_path(self._patrol_points)
+        self.patrol_seek = Seek(self.kinematic, self.patrol_follower.target)
+
+        self.investigate_follower = PathFollower()
+        self.investigate_seek = Seek(self.kinematic, self.investigate_follower.target)
+        self._known_alert_position: Optional[Point] = None
+        self._investigate_timer: float = 0.0
+
+        self.chase_pursue = Pursue(self.kinematic, player.kinematic)
+
+        self.set_brain(
+            BehaviorTree(
+                Selector(
+                    [
+                        Sequence(
+                            [Condition(self._sees_player), Action(self._spot_player)]
+                        ),
+                        Sequence(
+                            [
+                                Condition(self._is_investigating),
+                                Action(self._investigate_step),
+                            ]
+                        ),
+                        Action(self._patrol_step),
+                    ]
+                )
+            )
+        )
+
+    def _sees_player(self, agent: Agent) -> bool:
+        distance = (self.player.position - self.position).length()
+        return distance <= settings.GUARD_SIGHT_RADIUS and level.has_line_of_sight(
+            tuple(self.position), tuple(self.player.position)
+        )
+
+    def _spot_player(self, agent: Agent, dt: float) -> Status:
+        alert_position = (self.player.position.x, self.player.position.y)
+        self._known_alert_position = alert_position
+        self._investigate_timer = settings.GUARD_LOSE_INTEREST_TIME
+        self.blackboard.set("alert_position", alert_position)
+        self.blackboard.set("is_alerted", True)
+        self.set_steering_behavior(self.chase_pursue)
+        return Status.SUCCESS
+
+    def _is_investigating(self, agent: Agent) -> bool:
+        alert_position = self.blackboard.get("alert_position")
+        return self._investigate_timer > 0 or (
+            alert_position is not None and alert_position != self._known_alert_position
+        )
+
+    def _investigate_step(self, agent: Agent, dt: float) -> Status:
+        alert_position = self.blackboard.get("alert_position")
+
+        if alert_position != self._known_alert_position:
+            self._known_alert_position = alert_position
+            self._investigate_timer = settings.GUARD_LOSE_INTEREST_TIME
+            path = level.find_path(self.nav_graph, tuple(self.position), alert_position)
+            self.investigate_follower.set_path(path if path else [alert_position])
+
+        self._investigate_timer -= dt
+
+        if self._investigate_timer <= 0:
+            return Status.FAILURE
+
+        self.investigate_follower.update(self.position)
+        self.set_steering_behavior(self.investigate_seek)
+        return Status.SUCCESS
+
+    def _patrol_step(self, agent: Agent, dt: float) -> Status:
+        self.patrol_follower.update(self.position)
+
+        if self.patrol_follower.finished:
+            self._patrol_points.reverse()
+            self.patrol_follower.set_path(self._patrol_points)
+
+        self.set_steering_behavior(self.patrol_seek)
+        return Status.SUCCESS
+
+    def update(self, dt: float) -> None:
+        super().update(dt)
+        self.kinematic.position = level.resolve_circle_vs_obstacles(
+            self.kinematic.position, self.radius
+        )
+
+    def render(self, surface: pygame.Surface) -> None:
+        is_alert = self.steering_behavior is not self.patrol_seek
+        color = settings.COLOR_GUARD_ALERT if is_alert else settings.COLOR_GUARD_PATROL
+        center = (int(self.position.x), int(self.position.y))
+        pygame.draw.circle(surface, color, center, self.radius)
+
+        if self.velocity.length_squared() > 1:
+            tip = self.position + self.velocity.normalize() * (self.radius + 6)
+            pygame.draw.line(surface, color, center, tip, 2)
+
+        if is_alert:
+            pygame.draw.circle(
+                surface, color, (center[0], center[1] - self.radius - 8), 3
+            )

--- a/examples/nightwatch/src/entities/Guard.py
+++ b/examples/nightwatch/src/entities/Guard.py
@@ -52,7 +52,7 @@ class Guard(Agent):
         super().__init__(
             x=x,
             y=y,
-            max_speed=settings.GUARD_CHASE_SPEED,
+            max_speed=settings.GUARD_PATROL_SPEED,
             max_acceleration=settings.GUARD_CHASE_SPEED * 6,
             blackboard=blackboard,
         )
@@ -103,6 +103,7 @@ class Guard(Agent):
         self._investigate_timer = settings.GUARD_LOSE_INTEREST_TIME
         self.blackboard.set("alert_position", alert_position)
         self.blackboard.set("is_alerted", True)
+        self.kinematic.max_speed = settings.GUARD_CHASE_SPEED
         self.set_steering_behavior(self.chase_pursue)
         return Status.SUCCESS
 
@@ -126,11 +127,13 @@ class Guard(Agent):
         if self._investigate_timer <= 0:
             return Status.FAILURE
 
+        self.kinematic.max_speed = settings.GUARD_CHASE_SPEED
         self.investigate_follower.update(self.position)
         self.set_steering_behavior(self.investigate_seek)
         return Status.SUCCESS
 
     def _patrol_step(self, agent: Agent, dt: float) -> Status:
+        self.kinematic.max_speed = settings.GUARD_PATROL_SPEED
         self.patrol_follower.update(self.position)
 
         if self.patrol_follower.finished:

--- a/examples/nightwatch/src/entities/Player.py
+++ b/examples/nightwatch/src/entities/Player.py
@@ -1,0 +1,38 @@
+import pygame
+
+from gale.ai.agent import Agent
+
+import settings
+from src import level
+
+
+class Player(Agent):
+    def __init__(self, x: float, y: float) -> None:
+        super().__init__(x=x, y=y, max_speed=settings.PLAYER_SPEED)
+        self.radius = settings.PLAYER_RADIUS
+
+    def set_input_direction(self, dx: float, dy: float) -> None:
+        """
+        :param dx: Horizontal component of the currently-held movement keys, in [-1, 1].
+        :param dy: Vertical component of the currently-held movement keys, in [-1, 1].
+        """
+        direction = pygame.Vector2(dx, dy)
+        self.kinematic.velocity = (
+            direction.normalize() * settings.PLAYER_SPEED
+            if direction.length_squared() > 0
+            else pygame.Vector2()
+        )
+
+    def update(self, dt: float) -> None:
+        super().update(dt)
+        self.kinematic.position = level.resolve_circle_vs_obstacles(
+            self.kinematic.position, self.radius
+        )
+
+    def render(self, surface: pygame.Surface) -> None:
+        pygame.draw.circle(
+            surface,
+            settings.COLOR_PLAYER,
+            (int(self.position.x), int(self.position.y)),
+            self.radius,
+        )

--- a/examples/nightwatch/src/entities/__init__.py
+++ b/examples/nightwatch/src/entities/__init__.py
@@ -1,0 +1,3 @@
+from src.entities.Player import Player
+from src.entities.Guard import Guard
+from src.entities.Civilian import Civilian

--- a/examples/nightwatch/src/level.py
+++ b/examples/nightwatch/src/level.py
@@ -1,0 +1,174 @@
+"""
+The Nightwatch level: a fixed layout of wall obstacles and an exit,
+plus the helpers built on top of gale.ai.graph.NavGraph and
+gale.ai.search that let guards path around the walls.
+"""
+
+from typing import List, Sequence, Tuple
+
+import pygame
+
+from gale.ai.graph import NavGraph
+from gale.ai.search import a_star
+
+import settings
+
+Point = Tuple[float, float]
+
+BOUNDS = pygame.Rect(0, 0, settings.VIRTUAL_WIDTH, settings.VIRTUAL_HEIGHT)
+
+# Two walls forming a zigzag corridor: a gap at the bottom of the first
+# one, a gap at the top of the second one, connected by an open middle
+# lane.
+OBSTACLES: List[pygame.Rect] = [
+    pygame.Rect(200, 0, 24, 240),
+    pygame.Rect(416, 120, 24, 240),
+]
+
+EXIT_RECT = pygame.Rect(560, 20, 50, 40)
+
+PLAYER_START: Point = (20, 340)
+
+# (patrol point A, patrol point B) for each guard. Kept far enough from
+# PLAYER_START that the player doesn't start the level already spotted.
+GUARD_PATROLS: List[Tuple[Point, Point]] = [
+    ((160, 300), (320, 300)),
+    ((300, 60), (500, 60)),
+]
+
+CIVILIAN_START: Point = (320, 180)
+
+
+def has_line_of_sight(
+    a: Point, b: Point, obstacles: Sequence[pygame.Rect] = OBSTACLES
+) -> bool:
+    """
+    :returns: Whether the straight segment from a to b is not blocked by any of obstacles.
+    """
+    return not any(obstacle.clipline(a, b) for obstacle in obstacles)
+
+
+def _inflated_obstacles(clearance: float) -> List[pygame.Rect]:
+    return [o.inflate(clearance * 2, clearance * 2) for o in OBSTACLES]
+
+
+def build_nav_graph(
+    extra_points: Sequence[Point], clearance: float = settings.NAV_CLEARANCE
+) -> NavGraph:
+    """
+    Build a simple visibility graph: a node at every corner of every
+    (inflated, for clearance) obstacle plus every point in
+    extra_points, with an edge between any two nodes that have a clear
+    line of sight to each other.
+
+    :param extra_points: Extra nodes to always include, such as patrol points, the player's start, and the exit.
+    :param clearance: How far, in pixels, obstacles are inflated and their corner nodes pushed out, so a path keeps this much distance from walls.
+    :returns: The resulting NavGraph, ready to be searched with gale.ai.search.
+    """
+    inflated = _inflated_obstacles(clearance)
+    nodes: List[Point] = list(extra_points)
+
+    for obstacle in inflated:
+        for corner in (
+            obstacle.topleft,
+            obstacle.topright,
+            obstacle.bottomleft,
+            obstacle.bottomright,
+        ):
+            if BOUNDS.collidepoint(corner) and not any(
+                o.collidepoint(corner) for o in inflated
+            ):
+                nodes.append(corner)
+
+    graph = NavGraph()
+
+    for node in nodes:
+        graph.add_node(node)
+
+    for i, source in enumerate(nodes):
+        for target in nodes[i + 1 :]:
+            if has_line_of_sight(source, target, inflated):
+                graph.add_edge(source, target)
+
+    return graph
+
+
+def find_path(nav_graph: NavGraph, start: Point, goal: Point) -> List[Point]:
+    """
+    Find a path from start to goal using nav_graph, temporarily
+    connecting both points to it (they are not part of it, since they
+    move every time this is called).
+
+    :param nav_graph: The static NavGraph built by build_nav_graph.
+    :param start: The point to path from.
+    :param goal: The point to path to.
+    :returns: The list of points from start to goal (both included), or an empty list if goal is unreachable.
+    """
+    working = NavGraph()
+
+    for source, target, weight in nav_graph.edges:
+        working.add_edge(source, target, weight)
+
+    for point in (start, goal):
+        working.add_node(point)
+
+        for node in nav_graph.nodes:
+            if node != point and has_line_of_sight(point, node):
+                working.add_edge(point, node)
+
+    if has_line_of_sight(start, goal):
+        working.add_edge(start, goal)
+
+    def heuristic(node: Point, goal_node: Point) -> float:
+        return pygame.Vector2(node).distance_to(goal_node)
+
+    path = a_star(start, goal, working, heuristic)
+    return path or []
+
+
+def resolve_circle_vs_obstacles(
+    position: pygame.Vector2, radius: float
+) -> pygame.Vector2:
+    """
+    Push position out of any obstacle it overlaps, treating the moving
+    body as a circle of the given radius, and clamp it to the level
+    bounds. Meant to be called after integrating movement every frame.
+
+    :param position: The circle's center.
+    :param radius: The circle's radius.
+    :returns: The corrected position.
+    """
+    resolved = pygame.Vector2(position)
+
+    for obstacle in OBSTACLES:
+        closest = pygame.Vector2(
+            max(obstacle.left, min(resolved.x, obstacle.right)),
+            max(obstacle.top, min(resolved.y, obstacle.bottom)),
+        )
+        delta = resolved - closest
+
+        if delta.length_squared() == 0:
+            continue
+
+        distance = delta.length()
+
+        if distance < radius:
+            resolved += delta.normalize() * (radius - distance)
+
+    resolved.x = max(BOUNDS.left + radius, min(resolved.x, BOUNDS.right - radius))
+    resolved.y = max(BOUNDS.top + radius, min(resolved.y, BOUNDS.bottom - radius))
+    return resolved
+
+
+def render(surface: pygame.Surface, nav_graph: NavGraph) -> None:
+    """
+    Render the level's walls, exit, and (faintly, for demo purposes)
+    the nav graph's edges.
+    """
+    for source, target, _ in nav_graph.edges:
+        pygame.draw.line(surface, settings.COLOR_NAV_EDGE, source, target)
+
+    pygame.draw.rect(surface, settings.COLOR_EXIT, EXIT_RECT)
+
+    for obstacle in OBSTACLES:
+        pygame.draw.rect(surface, settings.COLOR_WALL, obstacle)

--- a/examples/nightwatch/src/path_follower.py
+++ b/examples/nightwatch/src/path_follower.py
@@ -1,0 +1,58 @@
+"""
+A small helper that advances through a list of waypoints, exposing a
+Kinematic target that a Seek (or Arrive) steering behavior can be built
+against once and reused for the whole path, since only the target's
+position is mutated as the path is followed.
+"""
+
+from typing import List, Sequence, Tuple
+
+import pygame
+
+from gale.ai.steering import Kinematic
+
+Point = Tuple[float, float]
+
+
+class PathFollower:
+    def __init__(self, arrival_radius: float = 12) -> None:
+        """
+        :param arrival_radius: Distance to a waypoint below which it counts as reached and the follower advances to the next one.
+        """
+        self.waypoints: List[Point] = []
+        self.index: int = 0
+        self.arrival_radius: float = arrival_radius
+        self.target: Kinematic = Kinematic()
+
+    def set_path(self, waypoints: Sequence[Point]) -> None:
+        """
+        :param waypoints: The new sequence of points to follow, in order.
+        """
+        self.waypoints = list(waypoints)
+        self.index = 0
+
+        if self.waypoints:
+            self.target.position = pygame.Vector2(self.waypoints[0])
+
+    @property
+    def finished(self) -> bool:
+        """
+        :returns: Whether every waypoint has been reached.
+        """
+        return self.index >= len(self.waypoints)
+
+    def update(self, position: pygame.Vector2) -> None:
+        """
+        Advance to the next waypoint if position is already close enough
+        to the current one.
+
+        :param position: The current position of whoever is following this path.
+        """
+        if self.finished:
+            return
+
+        if (self.target.position - position).length() <= self.arrival_radius:
+            self.index += 1
+
+            if not self.finished:
+                self.target.position = pygame.Vector2(self.waypoints[self.index])

--- a/examples/nightwatch/src/states/GameOverState.py
+++ b/examples/nightwatch/src/states/GameOverState.py
@@ -1,0 +1,36 @@
+import pygame
+
+from gale.input_handler import InputData
+from gale.state import BaseState
+from gale.text import render_text
+
+import settings
+
+
+class GameOverState(BaseState):
+    def on_input(self, input_id: str, input_data: InputData) -> None:
+        if input_id == "confirm" and input_data.pressed:
+            self.state_machine.change("title")
+        elif input_id == "restart" and input_data.pressed:
+            self.state_machine.change("play")
+
+    def render(self, surface: pygame.Surface) -> None:
+        surface.fill(settings.COLOR_BACKGROUND)
+        render_text(
+            surface,
+            "CAUGHT!",
+            settings.FONTS["large"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2 - 20,
+            settings.COLOR_ALERT_TEXT,
+            center=True,
+        )
+        render_text(
+            surface,
+            "Enter for title  -  Ctrl+R to try again",
+            settings.FONTS["small"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2 + 30,
+            settings.COLOR_TEXT,
+            center=True,
+        )

--- a/examples/nightwatch/src/states/PlayState.py
+++ b/examples/nightwatch/src/states/PlayState.py
@@ -1,0 +1,181 @@
+from typing import Any, Dict
+
+import pygame
+
+from gale.ai.blackboard import Blackboard
+from gale.factory import Factory
+from gale.input_handler import InputData
+from gale.particle_system import ParticleSystem
+from gale.state import BaseState
+from gale.text import render_text
+from gale.timer import Timer
+
+import settings
+from src import level
+from src.entities import Civilian, Guard, Player
+
+MOVEMENT_INPUTS = {
+    "move_left": (-1, 0),
+    "move_right": (1, 0),
+    "move_up": (0, -1),
+    "move_down": (0, 1),
+}
+
+
+class PlayState(BaseState):
+    def enter(self) -> None:
+        extra_points = [
+            level.PLAYER_START,
+            level.EXIT_RECT.center,
+            level.CIVILIAN_START,
+        ]
+        for point_a, point_b in level.GUARD_PATROLS:
+            extra_points.append(point_a)
+            extra_points.append(point_b)
+        self.nav_graph = level.build_nav_graph(extra_points)
+
+        self.blackboard = Blackboard({"alert_position": None, "is_alerted": False})
+        self.blackboard.observe("is_alerted", self._on_alert_changed)
+
+        player_factory = Factory(Player)
+        self.player = player_factory.create(*level.PLAYER_START)
+
+        guard_factory = Factory(Guard)
+        self.guards = [
+            guard_factory.create(
+                patrol_a[0],
+                patrol_a[1],
+                {
+                    "patrol_points": (patrol_a, patrol_b),
+                    "player": self.player,
+                    "nav_graph": self.nav_graph,
+                    "blackboard": self.blackboard,
+                },
+            )
+            for patrol_a, patrol_b in level.GUARD_PATROLS
+        ]
+
+        civilian_factory = Factory(Civilian)
+        self.civilian = civilian_factory.create(
+            *level.CIVILIAN_START, {"guards": self.guards}
+        )
+
+        self._keys_held: Dict[str, bool] = {key: False for key in MOVEMENT_INPUTS}
+
+        self.particle_system = ParticleSystem(0, 0, 40)
+        self.particle_system.set_life_time(0.3, 0.6)
+        self.particle_system.set_linear_acceleration(-40, -40, 40, 40)
+        self.particle_system.set_area_spread(6, 6)
+
+        self.ending = False
+        self.alert_flash_timer = 0.0
+
+        self.fade_alpha = 255
+        Timer.tween(0.5, [(self, {"fade_alpha": 0})])
+
+    def exit(self) -> None:
+        Timer.clear()
+
+    def _on_alert_changed(self, key: str, old_value: Any, new_value: Any) -> None:
+        if new_value and not old_value:
+            self.alert_flash_timer = 1.5
+            # This is a one-shot "spotted" pulse: reset it almost right
+            # away so the next sighting can trigger the flash again too.
+            Timer.after(0.15, lambda: self.blackboard.set("is_alerted", False))
+
+    def _update_player_input_direction(self) -> None:
+        direction = pygame.Vector2()
+
+        for input_id, (dx, dy) in MOVEMENT_INPUTS.items():
+            if self._keys_held[input_id]:
+                direction.x += dx
+                direction.y += dy
+
+        self.player.set_input_direction(direction.x, direction.y)
+
+    def on_input(self, input_id: str, input_data: InputData) -> None:
+        if input_id in MOVEMENT_INPUTS:
+            if input_data.pressed:
+                self._keys_held[input_id] = True
+            elif input_data.released:
+                self._keys_held[input_id] = False
+
+            self._update_player_input_direction()
+        elif input_id == "restart" and input_data.pressed:
+            self.state_machine.change("play")
+
+    def _end(self, next_state: str) -> None:
+        if self.ending:
+            return
+
+        self.ending = True
+        self.particle_system.x_mean = self.player.position.x
+        self.particle_system.y_mean = self.player.position.y
+        color = (
+            settings.COLOR_ALERT_TEXT
+            if next_state == "game_over"
+            else settings.COLOR_EXIT
+        )
+        self.particle_system.set_colors([(*color, 220), (*color, 255)])
+        self.particle_system.generate()
+        Timer.after(0.6, lambda: self.state_machine.change(next_state))
+
+    def update(self, dt: float) -> None:
+        self.particle_system.update(dt)
+
+        if self.alert_flash_timer > 0:
+            self.alert_flash_timer -= dt
+
+        if self.ending:
+            return
+
+        self.player.update(dt)
+        self.civilian.update(dt)
+
+        for guard in self.guards:
+            guard.update(dt)
+
+            if (
+                guard.position - self.player.position
+            ).length() <= settings.CATCH_RADIUS:
+                self._end("game_over")
+
+        if level.EXIT_RECT.collidepoint(self.player.position):
+            self._end("victory")
+
+    def render(self, surface: pygame.Surface) -> None:
+        surface.fill(settings.COLOR_BACKGROUND)
+        level.render(surface, self.nav_graph)
+
+        self.civilian.render(surface)
+
+        for guard in self.guards:
+            guard.render(surface)
+
+        self.player.render(surface)
+        self.particle_system.render(surface)
+
+        render_text(
+            surface,
+            "WASD/Arrows: move   Ctrl+R: restart",
+            settings.FONTS["small"],
+            8,
+            settings.VIRTUAL_HEIGHT - 20,
+            settings.COLOR_TEXT,
+        )
+
+        if self.alert_flash_timer > 0:
+            render_text(
+                surface,
+                "SPOTTED!",
+                settings.FONTS["medium"],
+                settings.VIRTUAL_WIDTH // 2,
+                20,
+                settings.COLOR_ALERT_TEXT,
+                center=True,
+            )
+
+        if self.fade_alpha > 0:
+            overlay = pygame.Surface(surface.get_size(), pygame.SRCALPHA)
+            overlay.fill((0, 0, 0, int(self.fade_alpha)))
+            surface.blit(overlay, (0, 0))

--- a/examples/nightwatch/src/states/TitleState.py
+++ b/examples/nightwatch/src/states/TitleState.py
@@ -1,0 +1,43 @@
+import pygame
+
+from gale.input_handler import InputData
+from gale.state import BaseState
+from gale.text import render_text
+
+import settings
+
+
+class TitleState(BaseState):
+    def on_input(self, input_id: str, input_data: InputData) -> None:
+        if input_id == "confirm" and input_data.pressed:
+            self.state_machine.change("play")
+
+    def render(self, surface: pygame.Surface) -> None:
+        surface.fill(settings.COLOR_BACKGROUND)
+        render_text(
+            surface,
+            "NIGHTWATCH",
+            settings.FONTS["large"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2 - 40,
+            settings.COLOR_TEXT,
+            center=True,
+        )
+        render_text(
+            surface,
+            "Sneak past the guards and reach the exit.",
+            settings.FONTS["medium"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2,
+            settings.COLOR_TEXT,
+            center=True,
+        )
+        render_text(
+            surface,
+            "WASD / Arrows to move  -  Enter to start  -  Ctrl+R to restart",
+            settings.FONTS["small"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2 + 30,
+            settings.COLOR_TEXT,
+            center=True,
+        )

--- a/examples/nightwatch/src/states/VictoryState.py
+++ b/examples/nightwatch/src/states/VictoryState.py
@@ -1,0 +1,36 @@
+import pygame
+
+from gale.input_handler import InputData
+from gale.state import BaseState
+from gale.text import render_text
+
+import settings
+
+
+class VictoryState(BaseState):
+    def on_input(self, input_id: str, input_data: InputData) -> None:
+        if input_id == "confirm" and input_data.pressed:
+            self.state_machine.change("title")
+        elif input_id == "restart" and input_data.pressed:
+            self.state_machine.change("play")
+
+    def render(self, surface: pygame.Surface) -> None:
+        surface.fill(settings.COLOR_BACKGROUND)
+        render_text(
+            surface,
+            "YOU MADE IT OUT",
+            settings.FONTS["large"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2 - 20,
+            settings.COLOR_EXIT,
+            center=True,
+        )
+        render_text(
+            surface,
+            "Enter for title  -  Ctrl+R to play again",
+            settings.FONTS["small"],
+            settings.VIRTUAL_WIDTH // 2,
+            settings.VIRTUAL_HEIGHT // 2 + 30,
+            settings.COLOR_TEXT,
+            center=True,
+        )

--- a/examples/nightwatch/src/states/__init__.py
+++ b/examples/nightwatch/src/states/__init__.py
@@ -1,0 +1,4 @@
+from src.states.TitleState import TitleState
+from src.states.PlayState import PlayState
+from src.states.GameOverState import GameOverState
+from src.states.VictoryState import VictoryState

--- a/examples/space_trip/README.md
+++ b/examples/space_trip/README.md
@@ -1,6 +1,52 @@
 # Space Trip
 
-A simple demo game of a flying saucer tripping through infinite space. You can take stars to accumulate a score.
+A simple demo game of a flying saucer tripping through infinite space.
+Stars scroll in from the right; fly into them to collect points before
+they scroll off the left edge.
+
+## Running it
+
+From the repository root, install gale itself in editable mode so it's
+importable from anywhere (only needed once):
+
+```bash
+pip install -e .
+```
+
+Then run the example from its own directory, since it looks for
+`settings.py` and `src/` next to `main.py`:
+
+```bash
+cd examples/space_trip
+python main.py
+```
+
+## Controls
+
+- Arrow keys: move the flying saucer
+- `Escape`: quit
+
+## What it uses
+
+This example is intentionally simple, closer to what `gale-admin
+create-project` scaffolds than to a full showcase — a good first
+example to read. See `examples/nightwatch` for a larger one built
+specifically to exercise `gale.ai`.
+
+- `gale.game.Game`: the `SpaceTrip` class driving the game loop.
+- `gale.state`: a single-state `StateMachine` (`PlayState`) — see its
+  `enter`/`update`/`render`/`on_input` methods for the basic shape
+  every state follows.
+- `gale.input_handler`: arrow keys bound to `left`/`right`/`up`/`down`
+  in `settings.py`, read in `PlayState.on_input`.
+- `gale.factory.Factory`: `Space` uses one to spawn `Star` instances.
+- `gale.timer.Timer`: `Space` uses `Timer.every` to spawn a new star
+  every few seconds.
+- `gale.text.render_text`: the score display in `PlayState.render`.
+
+`FlyingSaucer`'s own movement (in `src/FlyingSaucer.py`) is a small
+hand-rolled velocity integrator, not `gale.ai.steering` — it predates
+that module and is direct player input, not an autonomous behavior.
 
 ## Credits
 

--- a/gale/input_handler.py
+++ b/gale/input_handler.py
@@ -28,7 +28,31 @@ MOD_META: int = pygame.KMOD_META
 
 # Modifiers that gale takes into account to resolve key combos. Lock keys
 # such as Caps Lock or Num Lock are intentionally ignored.
-_COMBINABLE_MODIFIERS: int = MOD_SHIFT | MOD_CTRL | MOD_ALT | MOD_META
+_COMBINABLE_MODIFIERS: Tuple[int, int, int, int] = (
+    MOD_SHIFT,
+    MOD_CTRL,
+    MOD_ALT,
+    MOD_META,
+)
+
+
+def _normalize_modifiers(raw_modifiers: int) -> int:
+    """
+    Each MOD_* constant (e.g. MOD_CTRL) is actually the combination of
+    its left and right variants (e.g. KMOD_LCTRL | KMOD_RCTRL), but a
+    real key press only ever reports whichever single side was held,
+    never that combined value. This maps a raw pygame modifier state
+    to the combination of MOD_* constants a binding could have been
+    registered with, so holding either (or both) side of a modifier
+    matches a binding requiring it.
+    """
+    normalized = 0
+
+    for family in _COMBINABLE_MODIFIERS:
+        if raw_modifiers & family:
+            normalized |= family
+
+    return normalized
 
 
 class InvalidListenerException(Exception):
@@ -48,7 +72,7 @@ class KeyboardData:
 
     @staticmethod
     def get_action_key(event: pygame.event.Event) -> Tuple[int, int]:
-        return (event.mod & _COMBINABLE_MODIFIERS, event.key)
+        return (_normalize_modifiers(event.mod), event.key)
 
     @staticmethod
     def get_action_name():
@@ -367,7 +391,7 @@ class InputHandler:
         :param modifiers: A combination (bitwise or) of MOD_SHIFT, MOD_CTRL, MOD_ALT, and/or MOD_META that must be held for this binding to trigger. By default, MOD_NONE, meaning that the binding triggers regardless of the modifiers held, unless a more specific combo is also bound to the same key.
         """
         cls.input_binding[KeyboardData.get_action_name()][
-            (modifiers & _COMBINABLE_MODIFIERS, key)
+            (_normalize_modifiers(modifiers), key)
         ] = action_id
 
     @classmethod

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -51,3 +51,26 @@ class InputHandlerKeyComboTestCase(unittest.TestCase):
         InputHandler.set_keyboard_action(KEY_s, "save", modifiers=MOD_CTRL)
         InputHandler.handle_input(keydown(KEY_s, MOD_NONE))
         self.assertEqual(self.received, [])
+
+    def test_combo_triggers_holding_only_one_side_of_the_modifier(self) -> None:
+        # MOD_CTRL (like every MOD_* constant) is the combination of its
+        # left and right variants (KMOD_LCTRL | KMOD_RCTRL), but pygame
+        # only ever reports whichever single side is physically held,
+        # never that combined value. A binding registered with MOD_CTRL
+        # must still fire from a real, single-sided Ctrl press.
+        InputHandler.set_keyboard_action(KEY_s, "save", modifiers=MOD_CTRL)
+        InputHandler.handle_input(keydown(KEY_s, pygame.KMOD_LCTRL))
+        InputHandler.handle_input(keydown(KEY_s, pygame.KMOD_RCTRL))
+        self.assertEqual(self.received, ["save", "save"])
+
+    def test_combo_ignores_lock_keys(self) -> None:
+        InputHandler.set_keyboard_action(KEY_s, "save", modifiers=MOD_CTRL)
+        InputHandler.handle_input(
+            keydown(KEY_s, pygame.KMOD_LCTRL | pygame.KMOD_CAPS | pygame.KMOD_NUM)
+        )
+        self.assertEqual(self.received, ["save"])
+
+    def test_combo_does_not_trigger_with_a_different_modifier(self) -> None:
+        InputHandler.set_keyboard_action(KEY_s, "save", modifiers=MOD_CTRL)
+        InputHandler.handle_input(keydown(KEY_s, pygame.KMOD_LALT))
+        self.assertEqual(self.received, [])


### PR DESCRIPTION
## Summary

A small top-down stealth game — sneak past two patrolling guards and a civilian to reach the exit — built to test everything in `gale.ai` (and the rest of gale) in an actually running game, not just isolated doc snippets. Every visual is drawn with `pygame.draw` primitives, so it needs no image/font/sound assets to run.

What it exercises (see `examples/nightwatch/README.md` for the full breakdown):
- `gale.ai.agent.Agent`: `Player`, `Guard`, and `Civilian` are all subclasses, spawned via `gale.factory.Factory`.
- `gale.ai.behavior_tree`: `Guard`'s chase/investigate/patrol decision is a `Selector`/`Sequence`/`Condition`/`Action` tree. Every `Action` returns `SUCCESS` (never `RUNNING`), which is what makes the root `Selector` re-check from the top every tick instead of latching onto whichever branch ran last — documented in `Guard`'s docstring as a real, easy-to-miss behavior-tree nuance.
- `gale.ai.blackboard`: all `Guard`s share one `Blackboard`. A guard that spots the player posts `alert_position`/`is_alerted`, so the *other* guard investigates without ever seeing the player itself. The HUD's "SPOTTED!" flash is a `Blackboard.observe` callback, reacting immediately instead of polling every frame.
- `gale.ai.graph` / `gale.ai.search`: `src/level.py` builds a `NavGraph` once (a visibility graph over the level's wall corners); guards path across it with `a_star` to investigate the last known player position, walking around walls.
- `gale.ai.decision_tree`: `Civilian` uses a single `DecisionNode` instead — flee the nearest guard or wander — as a simpler alternative to a behavior tree.
- `gale.ai.steering`: `Kinematic`, `Seek`, `Pursue`, `Flee`, `Wander` drive every entity's movement.
- `gale.state`, `gale.timer`, `gale.particle_system`, `gale.input_handler` (including a `Ctrl+R` restart combo), `gale.text`.

`gale.ai.graph.DependencyGraph` is the one piece left out — it doesn't have a natural fit in real-time gameplay like this; it already has its own runnable example in `docs/examples/gale_ai.rst`.

## Fixes that landed on top while testing this PR

- **`Ctrl+R` didn't actually work**: every `MOD_*` constant in `gale.input_handler` (e.g. `MOD_CTRL`) is the combination of its left/right variants, but a real key press only ever reports one side — so an exact-match comparison never fired from a real keyboard. Fixed generally in `gale.input_handler` (`_normalize_modifiers`), with regression tests using a realistic single-sided modifier press.
- **The chase was unwinnable, not just hard**: `GUARD_PATROL_SPEED` was defined but never used (guards patrolled at full chase speed), and chase speed was nearly as fast as the player. Guards now genuinely patrol slower than they chase, chase speed is clearly below the player's top speed, sight radius is smaller, and the lose-interest timeout is shorter. Verified with two scripted bots (30 runs each): with the old constants, even a cautious "wait for a safe window, flee once spotted" bot lost every run (0/30); with the new constants it wins every run (30/30), while a reckless "beeline regardless" bot still loses every run (0/30) — careless play fails, careful play has a real path to victory.
- Documented how to actually run the examples (`pip install -e .` from the repo root first) in both example READMEs and the main README, after hitting `ModuleNotFoundError: No module named 'gale'` running one directly.

## Test plan
- [x] `pytest` (library suite) — 127 passing, unaffected
- [x] `black --check` — clean
- [x] `pre-commit run --all-files` — passing
- [x] Drove the game loop headlessly (SDL dummy driver) through several scripted scenarios and inspected rendered screenshots: title, patrol, a guard spotting the player while the other reacts purely via the blackboard, the chase giving up after the timeout and returning to patrol, civilian fleeing a nearby guard, wall collision (can't be pushed through a wall), victory screen + particle burst, game-over screen + particle burst, and the `Ctrl+R` restart combo (with a realistic single-sided modifier) — each checked both visually and against the actual object state
- [x] Balance verified quantitatively with scripted bots driving the real game loop, not just eyeballed (see above)
